### PR TITLE
Continue trace after printing vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,31 +108,48 @@ my_foo.foo(3) { puts _1 }
 ImLost.vars(my_foo)
 
 # output will look like
-#  > Foo.create(:foo!)
-#    /projects/foo.rb25
-#  > Foo.new(*)
-#    /projects/foo.rb6
-#  < Foo.new(*)
-#    = #<Foo:0x0000000100ab1188 @value=:foo!>
-#  < Foo.create(:foo!)
-#    = #<Foo:0x0000000100ab1188 @value=:foo!>
-#  > Foo#foo(1, *[], :none, **{}, &nil)
-#    /projects/foo.rb28
-#  > Foo#bar()
-#    /projects/foo.rb15
-#  < Foo#bar()
-#    = :bar
-#  < Foo#foo(1, *[], :none, **{}, &nil)
-#    = "1-none-[]-{}-bar"
-#  = /projects/foo.rb29
-#    instance variables:
-#    @value: "1-none-[]-{}-bar"
-#  = /projects/foo.rb32
-#    instance variables:
-#    @value: "2-some-[a,b,c]-{:name=>:value}-bar"
-#  = /projects/foo.rb35
-#    instance variables:
-#    @value: "3--[]-{}-bar"
+#   > Foo.create(:foo!)
+#     /projects/foo.rb:25
+#   > Foo.new(*)
+#     /projects/foo.rb:6
+#   < Foo.new(*)
+#     = #<Foo:0x00000001030810c0 @value=:foo!>
+#   < Foo.create(:foo!)
+#     = #<Foo:0x00000001030810c0 @value=:foo!>
+#   > Foo#foo(1, *[], :none, **{}, &nil)
+#     /projects/foo.rb:28
+#   > Foo#bar()
+#     /projects/foo.rb:15
+#   < Foo#bar()
+#     = :bar
+#   < Foo#foo(1, *[], :none, **{}, &nil)
+#     = "1-none-[]-{}-bar"
+#   = /projects/foo.rb:29
+#     instance variables:
+#     @value: "1-none-[]-{}-bar"
+#   > Foo#foo(2, *[:a, :b, :c], :some, **{:name=>:value}, &nil)
+#     /projects/foo.rb:31
+#   > Foo#bar()
+#     /projects/foo.rb:15
+#   < Foo#bar()
+#     = :bar
+#   < Foo#foo(2, *[:a, :b, :c], :some, **{:name=>:value}, &nil)
+#     = "2-some-[a,b,c]-{:name=>:value}-bar"
+#   = /projects/foo.rb:32
+#     instance variables:
+#     @value: "2-some-[a,b,c]-{:name=>:value}-bar"
+#   > Foo#foo(3, *[], nil, **{}, &#<Proc:0x00000001030aee30 /projects/foo.rb:34>)
+#     /projects/foo.rb:34
+#   > Foo#bar()
+#     /projects/foo.rb:15
+#   < Foo#bar()
+#     = :bar
+#   3--[]-{}-bar
+#   < Foo#foo(3, *[], nil, **{}, &#<Proc:0x00000001030aee30 /projects/foo.rb:34>)
+#     = nil
+#   = /projects/foo.rb:35
+#     instance variables:
+#     @value: "3--[]-{}-bar"
 ```
 
 See [examples dir](./examples) for more…

--- a/examples/foo.rb
+++ b/examples/foo.rb
@@ -35,28 +35,45 @@ my_foo.foo(3) { puts _1 }
 ImLost.vars(my_foo)
 
 # output will look like
-# > Foo.create(:foo!)
-#   /projects/foo.rb25
-# > Foo.new(*)
-#   /projects/foo.rb6
-# < Foo.new(*)
-#   = #<Foo:0x0000000100ab1188 @value=:foo!>
-# < Foo.create(:foo!)
-#   = #<Foo:0x0000000100ab1188 @value=:foo!>
-# > Foo#foo(1, *[], :none, **{}, &nil)
-#   /projects/foo.rb28
-# > Foo#bar()
-#   /projects/foo.rb15
-# < Foo#bar()
-#   = :bar
-# < Foo#foo(1, *[], :none, **{}, &nil)
-#   = "1-none-[]-{}-bar"
-# = /projects/foo.rb29
-#   instance variables:
-#   @value: "1-none-[]-{}-bar"
-# = /projects/foo.rb32
-#   instance variables:
-#   @value: "2-some-[a,b,c]-{:name=>:value}-bar"
-# = /projects/foo.rb35
-#   instance variables:
-#   @value: "3--[]-{}-bar"
+#   > Foo.create(:foo!)
+#     /projects/foo.rb:25
+#   > Foo.new(*)
+#     /projects/foo.rb:6
+#   < Foo.new(*)
+#     = #<Foo:0x00000001030810c0 @value=:foo!>
+#   < Foo.create(:foo!)
+#     = #<Foo:0x00000001030810c0 @value=:foo!>
+#   > Foo#foo(1, *[], :none, **{}, &nil)
+#     /projects/foo.rb:28
+#   > Foo#bar()
+#     /projects/foo.rb:15
+#   < Foo#bar()
+#     = :bar
+#   < Foo#foo(1, *[], :none, **{}, &nil)
+#     = "1-none-[]-{}-bar"
+#   = /projects/foo.rb:29
+#     instance variables:
+#     @value: "1-none-[]-{}-bar"
+#   > Foo#foo(2, *[:a, :b, :c], :some, **{:name=>:value}, &nil)
+#     /projects/foo.rb:31
+#   > Foo#bar()
+#     /projects/foo.rb:15
+#   < Foo#bar()
+#     = :bar
+#   < Foo#foo(2, *[:a, :b, :c], :some, **{:name=>:value}, &nil)
+#     = "2-some-[a,b,c]-{:name=>:value}-bar"
+#   = /projects/foo.rb:32
+#     instance variables:
+#     @value: "2-some-[a,b,c]-{:name=>:value}-bar"
+#   > Foo#foo(3, *[], nil, **{}, &#<Proc:0x00000001030aee30 /projects/foo.rb:34>)
+#     /projects/foo.rb:34
+#   > Foo#bar()
+#     /projects/foo.rb:15
+#   < Foo#bar()
+#     = :bar
+#   3--[]-{}-bar
+#   < Foo#foo(3, *[], nil, **{}, &#<Proc:0x00000001030aee30 /projects/foo.rb:34>)
+#     = nil
+#   = /projects/foo.rb:35
+#     instance variables:
+#     @value: "3--[]-{}-bar"

--- a/lib/im-lost/version.rb
+++ b/lib/im-lost/version.rb
@@ -2,5 +2,5 @@
 
 module ImLost
   # The version number of the gem.
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
- fix issue that trace stopped after printing vars of a traced object
- minor speedup when generate a call signature
- adapt README and example/foo.rb
- bump version to v1.0.2